### PR TITLE
Use shared Supabase browser client for auth-aware redirects

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,13 +1,23 @@
 "use client";
-import { createClient } from "@supabase/supabase-js";
-export const supabaseBrowser = () => {
-console.info('[supabaseBrowser] creating client', {
-url: process.env.NEXT_PUBLIC_SUPABASE_URL ? 'present' : 'MISSING',
-key: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? 'present' : 'MISSING',
-});
-return createClient(
-process.env.NEXT_PUBLIC_SUPABASE_URL!,
-process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-{ auth: { persistSession: true, autoRefreshToken: true } }
-);
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createBrowserClient } from "@supabase/ssr";
+
+let client: SupabaseClient | null = null;
+
+export const supabaseBrowser = (): SupabaseClient => {
+  if (client) return client;
+
+  console.info("[supabaseBrowser] creating client", {
+    url: process.env.NEXT_PUBLIC_SUPABASE_URL ? "present" : "MISSING",
+    key: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? "present" : "MISSING",
+  });
+
+  client = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: true, autoRefreshToken: true } }
+  );
+
+  return client;
 };


### PR DESCRIPTION
## Summary
- switch the browser Supabase client to use createBrowserClient so auth cookies sync with middleware
- reuse a single cached client instance to avoid recreating the browser client on every call

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68df5f7fbc7c832a82980d725451c9ef