### PR TITLE
Fix layout organization normalization and typed route navigation

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -23,17 +23,21 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
 
   const role = profile?.role ?? "client_viewer";
 
-  const organizationsRaw =
-    role === "owner"
-      ? (
-          await supabase
-            .from("organizations")
-            .select("id, name")
-            .order("name")
-        ).data ?? []
-      : profile?.organization
-      ? [profile.organization]
-      : [];
+  let organizationsRaw: { id: any; name: any }[] = [];
+
+  if (role === "owner") {
+    organizationsRaw =
+      (
+        await supabase
+          .from("organizations")
+          .select("id, name")
+          .order("name")
+      ).data ?? [];
+  } else if (profile?.organization) {
+    organizationsRaw = Array.isArray(profile.organization)
+      ? profile.organization
+      : [profile.organization];
+  }
 
   const organizations = organizationsRaw.map((org) => ({
     id: org.id,

--- a/components/layout/nav-config.ts
+++ b/components/layout/nav-config.ts
@@ -1,3 +1,4 @@
+import type { Route } from "next";
 import type { LucideIcon } from "lucide-react";
 import {
   LayoutDashboard,
@@ -15,7 +16,7 @@ import {
 export type Role = "owner" | "client_admin" | "client_viewer";
 
 export type NavItem = {
-  href: string;
+  href: Route;
   label: string;
   icon: LucideIcon;
   roles?: Role[];


### PR DESCRIPTION
## Summary
- normalize organization data in the app layout to always return arrays before mapping
- type navigation item hrefs using Next.js Route to satisfy typedRoutes checks

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_b_68df68e87c1c832ab955105d77146760