### PR TITLE
Handle missing Supabase env values

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -3,21 +3,23 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createBrowserClient } from "@supabase/ssr";
 
+import { getSupabaseCredentials } from "./env";
+
 let client: SupabaseClient | null = null;
 
 export const supabaseBrowser = (): SupabaseClient => {
   if (client) return client;
 
+  const { url, anonKey } = getSupabaseCredentials();
+
   console.info("[supabaseBrowser] creating client", {
-    url: process.env.NEXT_PUBLIC_SUPABASE_URL ? "present" : "MISSING",
-    key: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? "present" : "MISSING",
+    url: url ? "present" : "MISSING",
+    key: anonKey ? "present" : "MISSING",
   });
 
-  client = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { auth: { persistSession: true, autoRefreshToken: true } }
-  );
+  client = createBrowserClient(url, anonKey, {
+    auth: { persistSession: true, autoRefreshToken: true },
+  });
 
   return client;
 };

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -1,0 +1,33 @@
+type SupabaseCredentials = {
+  url: string;
+  anonKey: string;
+};
+
+let cachedCredentials: SupabaseCredentials | null = null;
+
+export function getSupabaseCredentials(): SupabaseCredentials {
+  if (cachedCredentials) {
+    return cachedCredentials;
+  }
+
+  const url =
+    (process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL)?.trim();
+  const anonKey =
+    (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+      process.env.SUPABASE_ANON_KEY)?.trim();
+
+  if (!url) {
+    throw new Error(
+      "Missing Supabase URL. Set NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL in your environment."
+    );
+  }
+
+  if (!anonKey) {
+    throw new Error(
+      "Missing Supabase anon key. Set NEXT_PUBLIC_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY in your environment."
+    );
+  }
+
+  cachedCredentials = { url, anonKey };
+  return cachedCredentials;
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,33 +1,33 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 
+import { getSupabaseCredentials } from "./env";
+
 export function supabaseServer() {
   console.info("[supabaseServer] init server client");
   const cookieStore = cookies();
 
-  return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          const v = cookieStore.get(name)?.value;
-          console.debug(
-            "[supabaseServer.cookies.get]",
-            name,
-            v ? "present" : "missing"
-          );
-          return v;
-        },
-        set(name: string, value: string, options: any) {
-          console.debug("[supabaseServer.cookies.set]", name);
-          cookieStore.set({ name, value, ...options });
-        },
-        remove(name: string, options: any) {
-          console.debug("[supabaseServer.cookies.remove]", name);
-          cookieStore.set({ name, value: "", ...options });
-        },
+  const { url, anonKey } = getSupabaseCredentials();
+
+  return createServerClient(url, anonKey, {
+    cookies: {
+      get(name: string) {
+        const v = cookieStore.get(name)?.value;
+        console.debug(
+          "[supabaseServer.cookies.get]",
+          name,
+          v ? "present" : "missing"
+        );
+        return v;
       },
-    }
-  );
+      set(name: string, value: string, options: any) {
+        console.debug("[supabaseServer.cookies.set]", name);
+        cookieStore.set({ name, value, ...options });
+      },
+      remove(name: string, options: any) {
+        console.debug("[supabaseServer.cookies.remove]", name);
+        cookieStore.set({ name, value: "", ...options });
+      },
+    },
+  });
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,21 @@
 /** @type {import('next').NextConfig} */
+const publicSupabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+const publicSupabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  process.env.SUPABASE_ANON_KEY;
+
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
-    typedRoutes: true
-  }
-}
+    typedRoutes: true,
+  },
+  env: {
+    ...(publicSupabaseUrl && { NEXT_PUBLIC_SUPABASE_URL: publicSupabaseUrl }),
+    ...(publicSupabaseAnonKey && {
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: publicSupabaseAnonKey,
+    }),
+  },
+};
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- add a shared helper to resolve Supabase credentials with fallbacks and validation
- update the Supabase browser and server clients to use the shared helper
- expose Supabase environment variables through `next.config.mjs` so existing secrets without the `NEXT_PUBLIC_` prefix work in the browser

## Testing
- not run (the available `npm run lint` command prompts for interactive setup)


------
https://chatgpt.com/codex/tasks/task_b_68df7300fa3c832aa4834795a055f856