### PR TITLE
Handle cookie mutations outside actions

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -22,11 +22,25 @@ export function supabaseServer() {
       },
       set(name: string, value: string, options: any) {
         console.debug("[supabaseServer.cookies.set]", name);
-        cookieStore.set({ name, value, ...options });
+        try {
+          cookieStore.set({ name, value, ...options });
+        } catch (error) {
+          console.warn(
+            "[supabaseServer.cookies.set] unable to set cookie (likely invoked outside a Server Action or Route Handler)",
+            error
+          );
+        }
       },
       remove(name: string, options: any) {
         console.debug("[supabaseServer.cookies.remove]", name);
-        cookieStore.set({ name, value: "", ...options });
+        try {
+          cookieStore.set({ name, value: "", ...options });
+        } catch (error) {
+          console.warn(
+            "[supabaseServer.cookies.remove] unable to remove cookie (likely invoked outside a Server Action or Route Handler)",
+            error
+          );
+        }
       },
     },
   });


### PR DESCRIPTION
## Summary
- wrap Supabase server cookie set/remove logic in try/catch so the runtime no longer throws when called outside a Server Action or Route Handler

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e028cfdec0832a88c16c5fed337b31