### PR TITLE
Split Supabase server client for read/write contexts

### DIFF
--- a/app/agency/calendar/page.tsx
+++ b/app/agency/calendar/page.tsx
@@ -3,7 +3,7 @@ import { revalidatePath } from 'next/cache';
 import AddPromoModal from '../../../components/AddPromoModal';
 import Calendar from '../../../components/Calendar';
 import { fetchCalendar, fetchOwnerOrgs } from '../../../lib/queries';
-import { createSupabaseServerClient } from '../../../lib/supabase/server';
+import { createSupabaseServerClient, createSupabaseActionClient } from '../../../lib/supabase/server';
 import { z } from 'zod';
 
 export default async function Page() {
@@ -31,7 +31,7 @@ export default async function Page() {
 
   async function createPromoAction(formData: FormData) {
     'use server';
-    const supa = createSupabaseServerClient();
+    const supa = createSupabaseActionClient();
     const raw = Object.fromEntries(formData.entries());
     const schema = z.object({
       org_id: z.string().uuid(),

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,16 +1,18 @@
 import '../../styles/globals.css';
 import { redirect } from 'next/navigation';
-import { createSupabaseServerClient } from '../../lib/supabase/server';
 import { landingRedirectPath } from '../../lib/auth';
+import { createSupabaseActionClient } from '../../lib/supabase/server';
 
 export default async function Page() {
   async function signIn(formData: FormData) {
     'use server';
-    const supabase = createSupabaseServerClient();
+    const supabase = createSupabaseActionClient();
     const email = String(formData.get('email') || '');
     const password = String(formData.get('password') || '');
     const { error } = await supabase.auth.signInWithPassword({ email, password });
     if (error) throw error;
+
+    // After auth, cookies are set by the action client; now decide landing.
     const path = await landingRedirectPath();
     redirect(path);
   }

--- a/app/org/[orgId]/inbox/[conversationId]/page.tsx
+++ b/app/org/[orgId]/inbox/[conversationId]/page.tsx
@@ -3,7 +3,7 @@ import ChatThread from '../../../../../components/ChatThread';
 import MessageComposer from '../../../../../components/MessageComposer';
 import { requireOrgAccess } from '../../../../../lib/auth';
 import { sendRcsMessage } from '../../../../../lib/pinnacle';
-import { createSupabaseServerClient } from '../../../../../lib/supabase/server';
+import { createSupabaseServerClient, createSupabaseActionClient } from '../../../../../lib/supabase/server';
 
 export default async function Page({
   params,
@@ -20,7 +20,7 @@ export default async function Page({
 
   async function sendMessageAction(formData: FormData) {
     'use server';
-    const supa = createSupabaseServerClient();
+    const supa = createSupabaseActionClient();
     const conversationId = String(formData.get('conversation_id'));
     const body = String(formData.get('body') || '');
 

--- a/app/org/[orgId]/settings/verification/page.tsx
+++ b/app/org/[orgId]/settings/verification/page.tsx
@@ -1,7 +1,7 @@
 import '../../../../../styles/globals.css';
 import { redirect } from 'next/navigation';
 import { requireOrgAccess } from '../../../../../lib/auth';
-import { createSupabaseServerClient } from '../../../../../lib/supabase/server';
+import { createSupabaseActionClient } from '../../../../../lib/supabase/server';
 
 function getBaseUrl() {
   if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
@@ -14,7 +14,7 @@ export default async function Page({ params }: { params: { orgId: string } }) {
 
   async function submit(formData: FormData) {
     'use server';
-    const supa = createSupabaseServerClient();
+    const supa = createSupabaseActionClient();
     const fields = Object.fromEntries(formData.entries());
     const { data: userData } = await supa.auth.getUser();
     const ins = await supa

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,8 +1,12 @@
 import { cookies, headers } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
-import { createClient } from '@supabase/supabase-js';
 import type { Database } from '../../types/database';
 
+/**
+ * Read-only Supabase client for Server Components.
+ *
+ * It never writes cookies, so it is safe to call during render.
+ */
 export function createSupabaseServerClient() {
   const cookieStore = cookies();
   return createServerClient<Database>(
@@ -10,16 +14,44 @@ export function createSupabaseServerClient() {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get: (name) => cookieStore.get(name)?.value,
-        set: (name, value, options) => cookieStore.set({ name, value, ...options }),
-        remove: (name, options) => cookieStore.set({ name, value: '', ...options, maxAge: 0 }),
+        get: (name: string) => cookieStore.get(name)?.value,
+        // No set/remove here — Server Components must not mutate cookies
       },
       headers: { 'x-forwarded-host': headers().get('x-forwarded-host') ?? undefined },
     }
   );
 }
 
+/**
+ * Write-enabled Supabase client for Server Actions and Route Handlers.
+ *
+ * This variant is allowed to modify cookies.
+ */
+export function createSupabaseActionClient() {
+  const cookieStore = cookies();
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (name: string) => cookieStore.get(name)?.value,
+        set: (name: string, value: string, options: any) =>
+          cookieStore.set({ name, value, ...options }),
+        remove: (name: string, options: any) =>
+          cookieStore.set({ name, value: '', ...options, maxAge: 0 }),
+      },
+      headers: { 'x-forwarded-host': headers().get('x-forwarded-host') ?? undefined },
+    }
+  );
+}
+
+/**
+ * Admin client for background jobs / webhooks (service role).
+ *
+ * Bypasses RLS by design — DO NOT use in pages/components.
+ */
 export function createSupabaseAdminClient() {
+  const { createClient } = require('@supabase/supabase-js');
   return createClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,


### PR DESCRIPTION
## Summary
- add dedicated read-only and write-enabled Supabase server helpers while keeping the admin client intact
- switch server actions (login, promo creation, inbox messaging, verification request) to the action client
- continue using the read-only helper for server component data fetching

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e47ef3bbe8832aa972f3038126f455