### PR TITLE
Fix Supabase SSR cookie handling and add dashboard chooser

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,80 @@
+import '../../styles/globals.css';
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '../../lib/supabase/server';
+
+/**
+ * Org chooser + landing router.
+ *
+ * If ?pickOrg=1 is present, always show chooser.
+ *
+ * Otherwise:
+ *
+ * owner/agency_staff -> /agency
+ *
+ * exactly one org -> /org/[orgId]
+ *
+ * else -> show chooser
+ */
+export default async function Page({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>;
+}) {
+  const supabase = createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) redirect('/login');
+
+  const forcePick = String(searchParams?.pickOrg ?? '') === '1';
+
+  const { data: profile } = await supabase.from('profiles').select('role').maybeSingle();
+  const { data: mems } = await supabase
+    .from('org_memberships')
+    .select('org_id, role, organizations:org_id(id, name)')
+    .order('created_at', { ascending: true });
+
+  const roles = (mems ?? []).map((m) => m.role);
+  if (!forcePick) {
+    if (profile?.role === 'owner' || roles.includes('owner') || roles.includes('agency_staff')) {
+      redirect('/agency');
+    }
+    if ((mems ?? []).length === 1) {
+      const membership = mems?.[0];
+      if (membership) {
+        redirect(`/org/${membership.org_id}`);
+      }
+    }
+  }
+
+  const orgs = (mems ?? [])
+    .map((m) => m.organizations)
+    .filter(Boolean) as { id: string; name: string }[];
+
+  return (
+    <div className="container">
+      <div className="card" style={{ maxWidth: 720, margin: '60px auto' }}>
+        <h2>Select an organization</h2>
+        <p>Choose which client dashboard you want to open.</p>
+        <div className="row" style={{ marginTop: 12 }}>
+          {orgs.length === 0 && <div>No organizations yet.</div>}
+          {orgs.map((o) => (
+            <div className="card col" key={o.id}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <strong>{o.name}</strong>
+                <a className="btn btn-primary" href={`/org/${o.id}`}>
+                  Open
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop: 16 }}>
+          <a className="btn" href="/agency">
+            Go to Agency view
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,81 +1,23 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
-import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
 
-import { getSupabaseCredentials } from "@/lib/supabase/env";
-
-const AUTH_ROUTES = new Set(["/login", "/reset-password"]);
-const PROTECTED_PREFIXES = [
-  "/dashboard",
-  "/promos",
-  "/rcs",
-  "/analytics",
-  "/clients",
-  "/users",
-  "/settings",
-  "/blasts",
-  "/reviews",
-  "/social",
-];
-
-export async function middleware(req: NextRequest) {
-  const res = NextResponse.next();
-  const { url, anonKey } = getSupabaseCredentials();
-
-  const supabase = createServerClient(url, anonKey, {
-    cookies: {
-      get(name: string) {
-        return req.cookies.get(name)?.value;
-      },
-      set(name: string, value: string, options: CookieOptions) {
-        res.cookies.set({ name, value, ...(options ?? {}) });
-      },
-      remove(name: string, options: CookieOptions) {
-        res.cookies.set({ name, value: "", ...(options ?? {}) });
-      },
-    },
-  });
-
-  await supabase.auth.getSession();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
+/**
+ * Keep middleware minimal. Do NOT guess landing here.
+ *
+ * Only redirect root "/" to "/login" so we avoid 404s and loops.
+ *
+ * All other routing decisions happen server-side in pages.
+ */
+export function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
-  const isAuthRoute = AUTH_ROUTES.has(pathname);
-  const isProtected = PROTECTED_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`)
-  );
 
-  if (!user && isProtected) {
-    const redirectUrl = req.nextUrl.clone();
-    redirectUrl.pathname = "/login";
-    return NextResponse.redirect(redirectUrl);
+  if (pathname === '/') {
+    return NextResponse.redirect(new URL('/login', req.url));
   }
 
-  if (user && isAuthRoute) {
-    const redirectUrl = req.nextUrl.clone();
-    redirectUrl.pathname = "/dashboard";
-    return NextResponse.redirect(redirectUrl);
-  }
-
-  return res;
+  return NextResponse.next();
 }
 
 export const config = {
-  matcher: [
-    "/dashboard/:path*",
-    "/promos/:path*",
-    "/rcs/:path*",
-    "/analytics",
-    "/analytics/:path*",
-    "/clients/:path*",
-    "/users/:path*",
-    "/settings/:path*",
-    "/blasts/:path*",
-    "/reviews/:path*",
-    "/social/:path*",
-    "/login",
-    "/reset-password",
-  ],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 };


### PR DESCRIPTION
## Summary
- switch Supabase SSR client helpers to the new getAll/setAll cookie API and restrict writes to actions and route handlers
- update landing redirect logic and add a /dashboard page for choosing an organization
- simplify middleware to only redirect the root path to /login to avoid loops and 404s

## Testing
- not run (next lint prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_b_68e481d9d6b0832aa2773c2bf8909476