### PR TITLE
feat: modernize auth experience

### DIFF
--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -1,0 +1,71 @@
+'use server';
+
+import { headers } from 'next/headers';
+import { createSupabaseActionClient } from '@/lib/supabase/server';
+
+type ActionState = { ok: boolean; message?: string };
+
+function appOrigin() {
+  const h = headers();
+  const origin = h.get('origin');
+  if (origin) return origin;
+  const host = h.get('host') ?? 'localhost:3000';
+  const scheme = host.startsWith('localhost') ? 'http' : 'https';
+  return `${scheme}://${host}`;
+}
+
+export async function signInAction(_prev: ActionState, formData: FormData): Promise<ActionState> {
+  const email = String(formData.get('email') ?? '');
+  const password = String(formData.get('password') ?? '');
+  const supabase = createSupabaseActionClient();
+
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) {
+    return { ok: false, message: 'Wrong email or password.' };
+  }
+  return { ok: true };
+}
+
+export async function signUpAction(_prev: ActionState, formData: FormData): Promise<ActionState> {
+  const email = String(formData.get('email') ?? '');
+  const password = String(formData.get('password') ?? '');
+  const supabase = createSupabaseActionClient();
+
+  const redirectTo = `${appOrigin()}/reset-password`;
+  const { error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: { emailRedirectTo: redirectTo },
+  });
+
+  if (error) {
+    const already = error.message?.toLowerCase().includes('already');
+    return { ok: false, message: already ? 'You already have an account. Please sign in.' : error.message };
+  }
+  return {
+    ok: true,
+    message: 'Check your email to confirm your account. After confirming, you can sign in.',
+  };
+}
+
+export async function sendResetAction(_prev: ActionState, formData: FormData): Promise<ActionState> {
+  const email = String(formData.get('email') ?? '');
+  const supabase = createSupabaseActionClient();
+  const redirectTo = `${appOrigin()}/reset-password`;
+
+  const { error } = await supabase.auth.resetPasswordForEmail(email, { redirectTo });
+  if (error) return { ok: false, message: 'Could not send reset email. Please try again.' };
+  return { ok: true, message: 'Reset link sent! Check your inbox.' };
+}
+
+export async function updatePasswordAction(_prev: ActionState, formData: FormData): Promise<ActionState> {
+  const password = String(formData.get('password') ?? '');
+  const confirm = String(formData.get('confirm') ?? '');
+  if (!password || password.length < 8) return { ok: false, message: 'Password must be at least 8 characters.' };
+  if (password !== confirm) return { ok: false, message: 'Passwords do not match.' };
+
+  const supabase = createSupabaseActionClient();
+  const { error } = await supabase.auth.updateUser({ password });
+  if (error) return { ok: false, message: 'Could not update password. Please try the link again.' };
+  return { ok: true, message: 'Password updated! You can sign in now.' };
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,34 +1,18 @@
-import '../../styles/globals.css';
-import { redirect } from 'next/navigation';
-import { landingRedirectPath } from '../../lib/auth';
-import { createSupabaseActionClient } from '../../lib/supabase/server';
+import '@/styles/globals.css';
+import AuthCard from '@/components/AuthCard';
 
-export default async function Page() {
-  async function signIn(formData: FormData) {
-    'use server';
-    const supabase = createSupabaseActionClient();
-    const email = String(formData.get('email') || '');
-    const password = String(formData.get('password') || '');
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
-    if (error) throw error;
+export const metadata = {
+  title: 'Sign in • Title',
+  description: 'RCS promos for golf courses',
+};
 
-    // After auth, cookies are set by the action client; now decide landing.
-    const path = await landingRedirectPath();
-    redirect(path);
-  }
-
+export default function Page() {
   return (
-    <div className="container">
-      <div className="card" style={{ maxWidth: 420, margin: '80px auto' }}>
-        <h2>Sign in to Title</h2>
-        <form action={signIn} style={{ display: 'grid', gap: 12 }}>
-          <input className="input" name="email" placeholder="Email" type="email" required />
-          <input className="input" name="password" placeholder="Password" type="password" required />
-          <button className="btn btn-primary" type="submit">
-            Sign in
-          </button>
-        </form>
-      </div>
-    </div>
+    <main className="login-bg">
+      <AuthCard />
+      <footer className="login-footer">
+        <span>© {new Date().getFullYear()} Title • Golf-first RCS</span>
+      </footer>
+    </main>
   );
 }

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useFormState } from 'react-dom';
+import { updatePasswordAction } from '@/app/login/actions';
+import '@/styles/globals.css';
+
+type ActionState = { ok: boolean; message?: string };
+
+export default function ResetPasswordPage() {
+  const [state, action] = useFormState<ActionState, FormData>(updatePasswordAction, { ok: false });
+
+  return (
+    <main className="login-bg">
+      <div className="auth-wrap">
+        <div className="brand">
+          <div className="flag" />
+          <span>Title</span>
+        </div>
+        <div className="auth-card">
+          <h2 className="headline">Set a new password</h2>
+          <p className="subtext">Enter a new password for your account.</p>
+          <form action={action} className="form-grid">
+            <input name="password" type="password" placeholder="New password" required minLength={8} className="input" />
+            <input name="confirm" type="password" placeholder="Confirm new password" required minLength={8} className="input" />
+            {state.message && <div className={state.ok ? 'notice' : 'alert'}>{state.message}</div>}
+            <button className="btn-primary w-full" type="submit">Update password</button>
+          </form>
+          <div className="muted hint">
+            Done? <a className="link" href="/login">Return to sign in</a>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/AuthCard.tsx
+++ b/components/AuthCard.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+import { signInAction, signUpAction, sendResetAction } from '@/app/login/actions';
+
+type ActionState = { ok: boolean; message?: string };
+
+function SubmitButton({ children }: { children: React.ReactNode }) {
+  const { pending } = useFormStatus();
+  return (
+    <button className="btn-primary w-full" type="submit" disabled={pending}>
+      {pending ? 'Please wait…' : children}
+    </button>
+  );
+}
+
+export default function AuthCard() {
+  const [mode, setMode] = useState<'signin' | 'signup'>('signin');
+  const [showForgot, setShowForgot] = useState(false);
+
+  const [signInState, signInActionBound] = useFormState<ActionState, FormData>(signInAction, { ok: false });
+  const [signUpState, signUpActionBound] = useFormState<ActionState, FormData>(signUpAction, { ok: false });
+  const [resetState, resetActionBound] = useFormState<ActionState, FormData>(sendResetAction, { ok: false });
+
+  const headline = useMemo(() => (mode === 'signin' ? 'Welcome back' : 'Create your account'), [mode]);
+
+  const shouldShowForgot = showForgot || (!!signInState.message && !signInState.ok);
+
+  return (
+    <div className="auth-wrap">
+      <div className="brand">
+        <div className="flag" />
+        <span>Title</span>
+      </div>
+
+      <div className="auth-card">
+        <div className="tabs">
+          <button
+            className={mode === 'signin' ? 'tab active' : 'tab'}
+            onClick={() => setMode('signin')}
+            type="button"
+          >
+            Sign in
+          </button>
+          <button
+            className={mode === 'signup' ? 'tab active' : 'tab'}
+            onClick={() => setMode('signup')}
+            type="button"
+          >
+            Sign up
+          </button>
+        </div>
+
+        <h2 className="headline">{headline}</h2>
+        <p className="subtext">Golf-ready messaging for your courses.</p>
+
+        {mode === 'signin' && (
+          <form action={signInActionBound} className="form-grid">
+            <input name="email" type="email" placeholder="Email" required className="input" />
+            <input name="password" type="password" placeholder="Password" required className="input" />
+            {signInState.message && <div className="alert">{signInState.message}</div>}
+            <SubmitButton>Sign in</SubmitButton>
+          </form>
+        )}
+
+        {mode === 'signup' && (
+          <form action={signUpActionBound} className="form-grid">
+            <input name="email" type="email" placeholder="Email" required className="input" />
+            <input name="password" type="password" placeholder="Password (min 8 chars)" required minLength={8} className="input" />
+            {signUpState.message && <div className={signUpState.ok ? 'notice' : 'alert'}>{signUpState.message}</div>}
+            <SubmitButton>Create account</SubmitButton>
+            <div className="muted hint">
+              Already have an account?{' '}
+              <button className="link" type="button" onClick={() => setMode('signin')}>
+                Sign in
+              </button>
+            </div>
+          </form>
+        )}
+
+        <div className="forgot">
+          <button className="link small" type="button" onClick={() => setShowForgot((s) => !s)}>
+            {shouldShowForgot ? 'Hide password reset' : 'Forgot password?'}
+          </button>
+          {shouldShowForgot && (
+            <form action={resetActionBound} className="form-inline">
+              <input name="email" type="email" placeholder="Your email" required className="input" />
+              <SubmitButton>Send reset link</SubmitButton>
+              {resetState.message && <div className={resetState.ok ? 'notice' : 'alert'}>{resetState.message}</div>}
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,24 +1,27 @@
 :root{
---title-green:#8BC34A;
---bg:#FFFFFF;
---ink:#0f172a;
---muted:#f6f7f8;
---border:#e5e7eb;
+  --title-green:#8BC34A;
+  --bg:#FFFFFF;
+  --ink:#0f172a;
+  --muted:#f6f7f8;
+  --border:#e5e7eb;
+  --card:#ffffff;
+  --shadow:0 20px 50px rgba(0,0,0,.08),0 8px 20px rgba(0,0,0,.06);
 }
+*{box-sizing:border-box}
 html,body{height:100%;}
 body{
-background:var(--bg);
-color:var(--ink);
-font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
-margin:0;
+  background:var(--bg);
+  color:var(--ink);
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+  margin:0;
 }
 .container{max-width:1200px;margin:0 auto;padding:24px;}
 .card{
-background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:16px;
-box-shadow:0 1px 2px rgba(0,0,0,0.04);
+  background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:16px;
+  box-shadow:0 1px 2px rgba(0,0,0,0.04);
 }
 .btn{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:10px;border:1px solid var(--border);background:var(--muted);cursor:pointer;font-weight:600;}
-.btn-primary{background:var(--title-green);border-color:var(--title-green);color:#0b3d0b;}
+.btn-primary{background:var(--title-green);border:1px solid var(--title-green);color:#0b2510;padding:12px 14px;border-radius:12px;font-weight:700;cursor:pointer;box-shadow:0 8px 18px rgba(139,195,74,.35);} 
 .btn-secondary{background:var(--muted);}
 .tabbar{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px}
 .badge{display:inline-block;padding:4px 8px;border-radius:999px;background:var(--muted);font-size:12px;}
@@ -27,3 +30,43 @@ box-shadow:0 1px 2px rgba(0,0,0,0.04);
 .row{display:flex;gap:12px;flex-wrap:wrap;}
 .col{flex:1;min-width:240px;}
 h1,h2,h3{margin:0 0 12px 0}
+main.login-bg{
+  min-height:100dvh;
+  display:flex;align-items:center;justify-content:center;flex-direction:column;
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(139,195,74,.18), transparent 60%),
+    radial-gradient(900px 500px at -10% 120%, rgba(139,195,74,.20), transparent 60%),
+    linear-gradient(180deg, #fdfefd 0%, #f7fbf5 100%);
+}
+.login-footer{margin-top:24px;color:#5b6573;font-size:.9rem}
+.auth-wrap{width:100%;max-width:460px;padding:16px}
+.brand{display:flex;gap:10px;align-items:center;justify-content:center;margin-bottom:10px}
+.brand .flag{width:16px;height:16px;border-left:3px solid var(--ink);border-bottom:3px solid var(--ink);position:relative;transform:skewX(-12deg)}
+.brand .flag::after{content:'';position:absolute;left:0;top:-8px;width:14px;height:10px;background:var(--title-green);clip-path:polygon(0 0,100% 20%,0 100%)}
+.brand span{font-weight:800;letter-spacing:.5px}
+.auth-card{
+  background:var(--card);
+  border-radius:16px;padding:28px;
+  box-shadow:var(--shadow);
+  border:1px solid rgba(15,23,42,.06);
+}
+.headline{margin:6px 0 4px 0;font-size:1.4rem}
+.subtext{color:#64748b;margin-bottom:14px}
+.tabs{display:flex;gap:8px;margin-bottom:12px}
+.tab{flex:1;padding:10px 12px;border-radius:12px;background:#eceff3;color:#475569;border:1px solid transparent;transition:.15s}
+.tab.active{background:#ffffff;border-color:#dbe2ea;box-shadow:0 6px 14px rgba(0,0,0,.05)}
+.form-grid{display:grid;gap:10px}
+.form-inline{display:flex;gap:8px;margin-top:10px}
+.input{
+  padding:12px 14px;border-radius:12px;border:1px solid #dbe2ea;background:#fff;font-size:14px;outline:0;
+}
+.input:focus{border-color:var(--title-green);box-shadow:0 0 0 3px rgba(139,195,74,.15)}
+.btn-primary:disabled{opacity:.6;cursor:not-allowed;box-shadow:none}
+.w-full{width:100%}
+.alert{background:#fff3f3;border:1px solid #ffd4d4;color:#9b1c1c;padding:10px 12px;border-radius:10px}
+.notice{background:#f3fff6;border:1px solid #c8f3d2;color:#065f46;padding:10px 12px;border-radius:10px}
+.muted{color:#5b6573}
+.hint{margin-top:10px}
+.link{color:#0b5f1e;text-decoration:underline;cursor:pointer}
+.link.small{font-size:.9rem}
+.forgot{margin-top:14px;display:grid;gap:8px}


### PR DESCRIPTION
## Summary
- replace the login page with a tabbed sign in/sign up experience backed by Supabase server actions
- add a forgot password flow and reset page that updates the user password via Supabase recovery session
- refresh global styles with a golf-themed gradient card layout and inline status messaging helpers

## Testing
- npm run lint *(fails: next not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e490df63a0832aa3784f47e4ae7671