### PR TITLE
Fix Supabase browser client export and modal validation

### DIFF
--- a/app/agency/calendar/AddPromoModal.tsx
+++ b/app/agency/calendar/AddPromoModal.tsx
@@ -1,63 +1,144 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
-import { createPromoAction } from "./actions";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 
-type Org = { id: string; name: string };
-type Tmpl = { id: string; name: string; org_id: string };
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="block space-y-1">
+      <span className="text-sm font-medium">{label}</span>
+      {children}
+    </label>
+  );
+}
 
-export default function AddPromoModal({
-  orgOptions,
-  templateOptions,
-}: {
-  orgOptions: Org[];
-  templateOptions: Tmpl[];
-}) {
-  const [open, setOpen] = useState(false);
-  const [pending, start] = useTransition();
-
-  const [orgId, setOrgId] = useState<string>("");
-  const [courseId, setCourseId] = useState<string>("");
-  const [courses, setCourses] = useState<{ id: string; name: string }[]>([]);
-  const [err, setErr] = useState<string>("");
-  const [templateId, setTemplateId] = useState<string>("");
-
+export default function AddPromoModal() {
   const supabase = useMemo(() => createSupabaseBrowserClient(), []);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const [orgs, setOrgs] = useState<Array<{ id: string; name: string }>>([]);
+  const [courses, setCourses] = useState<Array<{ id: string; name: string; timezone: string }>>([]);
+  const [templates, setTemplates] = useState<Array<{ id: string; name: string }>>([]);
+
+  const [orgId, setOrgId] = useState("");
+  const [courseId, setCourseId] = useState("");
+  const [templateId, setTemplateId] = useState("");
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [scheduledAt, setScheduledAt] = useState("");
+  const [timezone, setTimezone] = useState("");
+
+  useEffect(() => {
+    (async () => {
+      const { data, error } = await supabase.from("organizations").select("id,name").order("name");
+      if (!error && data) {
+        setOrgs(data as Array<{ id: string; name: string }>);
+      }
+    })();
+  }, [supabase]);
+
+  useEffect(() => {
+    if (!orgId) {
+      setCourses([]);
+      setTemplates([]);
+      setCourseId("");
+      setTemplateId("");
+      setTimezone("");
+      return;
+    }
+
+    (async () => {
+      const [{ data: courseData }, { data: templateData }] = await Promise.all([
+        supabase.from("courses").select("id,name,timezone").eq("org_id", orgId).order("name"),
+        supabase.from("rcs_templates").select("id,name").eq("org_id", orgId).order("name"),
+      ]);
+
+      setCourses((courseData as Array<{ id: string; name: string; timezone: string }>) ?? []);
+      setTemplates((templateData as Array<{ id: string; name: string }>) ?? []);
+    })();
+  }, [orgId, supabase]);
+
+  useEffect(() => {
+    const course = courses.find((c) => c.id === courseId);
+    setTimezone(course?.timezone ?? "");
+  }, [courseId, courses]);
 
   const resetForm = () => {
     setOrgId("");
     setCourseId("");
-    setCourses([]);
     setTemplateId("");
+    setName("");
+    setDescription("");
+    setScheduledAt("");
+    setTimezone("");
   };
 
-  // Load courses whenever org changes
-  useEffect(() => {
-    setCourseId("");
-    setCourses([]);
-    setTemplateId("");
-    setErr("");
-    if (!orgId) return;
-    (async () => {
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!orgId) return alert("Please choose an Organization.");
+    if (!courseId) return alert("Please choose a Course.");
+    if (!templateId) return alert("Please choose a Template.");
+    if (!name.trim()) return alert("Please enter a Campaign Name.");
+    if (!scheduledAt) return alert("Please pick a Scheduled time.");
+    if (!timezone) return alert("Missing timezone (comes from Course).");
+
+    setLoading(true);
+    try {
+      const { data: auth } = await supabase.auth.getUser();
+      const userId = auth.user?.id ?? null;
+
+      const payload = {
+        org_id: orgId,
+        course_id: courseId,
+        template_id: templateId,
+        name,
+        description: description || null,
+        scheduled_at: new Date(scheduledAt).toISOString(),
+        timezone,
+        status: "scheduled",
+        audience_kind: "all_contacts",
+        client_visible: true,
+        created_by: userId,
+      } as const;
+
       const { data, error } = await supabase
-        .from("courses")
-        .select("id, name")
-        .eq("org_id", orgId)
-        .order("name", { ascending: true });
+        .from("campaigns")
+        .insert(payload)
+        .select("id")
+        .single();
+
       if (error) {
-        setErr("Could not load courses. Please check your access.");
+        console.error(error);
+        alert(`Failed to create campaign: ${error.message}`);
         return;
       }
-      setCourses(data ?? []);
-    })();
-  }, [orgId, supabase]);
 
-  // Filter templates by selected org
-  const templatesForOrg = useMemo(
-    () => (orgId ? templateOptions.filter((t) => t.org_id === orgId) : []),
-    [orgId, templateOptions],
-  );
+      try {
+        await supabase.from("calendar_events").insert({
+          org_id: orgId,
+          course_id: courseId,
+          campaign_id: data.id,
+          title: name,
+          description: description || null,
+          start_time: new Date(scheduledAt).toISOString(),
+          status: "scheduled",
+          is_client_visible: true,
+          event_type: "campaign",
+          event_status: "scheduled",
+        });
+      } catch (calendarError) {
+        console.warn("Calendar insert skipped/failed:", calendarError);
+      }
+
+      alert("Campaign scheduled!");
+      resetForm();
+      setOpen(false);
+    } finally {
+      setLoading(false);
+    }
+  }
 
   return (
     <>
@@ -65,7 +146,6 @@ export default function AddPromoModal({
         className="btn-primary"
         onClick={() => {
           resetForm();
-          setErr("");
           setOpen(true);
         }}
       >
@@ -75,139 +155,103 @@ export default function AddPromoModal({
         <div className="modal-overlay">
           <div className="modal">
             <h3 className="section-title">Schedule RCS Promo</h3>
-
-            {err && (
-              <div className="alert-error" style={{ marginBottom: 10 }}>
-                {err}
-              </div>
-            )}
-
-            <form
-              action={(fd) => {
-                setErr("");
-                start(async () => {
-                  try {
-                    const payload = {
-                      org_id: fd.get("org_id") as string,
-                      course_id: fd.get("course_id") as string,
-                      template_id: fd.get("template_id") as string,
-                      name: fd.get("name") as string,
-                      description: (fd.get("description") as string) || null,
-                      scheduled_at: fd.get("scheduled_at") as string,
-                      timezone:
-                        Intl.DateTimeFormat().resolvedOptions().timeZone ||
-                        "UTC",
-                    };
-                    await createPromoAction(payload);
-                    resetForm();
-                    setOpen(false);
-                  } catch (e: any) {
-                    setErr(e?.message || "Failed to schedule promo.");
-                  }
-                });
-              }}
-            >
-              <label className="lbl">
-                Organization
+            <form onSubmit={handleSubmit} className="space-y-4 p-4">
+              <Field label="Organization">
                 <select
-                  name="org_id"
-                  required
                   value={orgId}
-                  onChange={(e) => setOrgId(e.target.value)}
+                  onChange={(event) => setOrgId(event.target.value)}
+                  className="w-full border rounded p-2"
+                  required
                 >
-                  <option value="" disabled>
-                    Select org
-                  </option>
-                  {orgOptions.map((o) => (
-                    <option key={o.id} value={o.id}>
-                      {o.name}
+                  <option value="">Select organization…</option>
+                  {orgs.map((org) => (
+                    <option key={org.id} value={org.id}>
+                      {org.name}
                     </option>
                   ))}
                 </select>
-              </label>
+              </Field>
 
-              <label className="lbl">
-                Course
+              <Field label="Course (required)">
                 <select
-                  name="course_id"
-                  required
                   value={courseId}
-                  onChange={(e) => setCourseId(e.target.value)}
-                  disabled={!orgId || !courses.length}
-                >
-                  <option value="" disabled>
-                    {!orgId
-                      ? "Select an org first"
-                      : courses.length
-                        ? "Select course"
-                        : "No courses found"}
-                  </option>
-                  {courses.map((c) => (
-                    <option key={c.id} value={c.id}>
-                      {c.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-
-              <label className="lbl">
-                Template
-                <select
-                  key={orgId}
-                  name="template_id"
+                  onChange={(event) => setCourseId(event.target.value)}
+                  className="w-full border rounded p-2"
                   required
-                  value={templateId}
-                  onChange={(e) => setTemplateId(e.target.value)}
-                  disabled={!orgId || !templatesForOrg.length}
                 >
-                  <option value="" disabled>
-                    {!orgId
-                      ? "Select an org first"
-                      : templatesForOrg.length
-                        ? "Select template"
-                        : "No templates found"}
-                  </option>
-                  {templatesForOrg.map((t) => (
-                    <option key={t.id} value={t.id}>
-                      {t.name}
+                  <option value="">Select course…</option>
+                  {courses.map((course) => (
+                    <option key={course.id} value={course.id}>
+                      {course.name}
                     </option>
                   ))}
                 </select>
-              </label>
+              </Field>
 
-              <label className="lbl">
-                Name/title
-                <input name="name" required placeholder="Promo title" />
-              </label>
+              <Field label="Template">
+                <select
+                  value={templateId}
+                  onChange={(event) => setTemplateId(event.target.value)}
+                  className="w-full border rounded p-2"
+                  required
+                >
+                  <option value="">Select RCS template…</option>
+                  {templates.map((template) => (
+                    <option key={template.id} value={template.id}>
+                      {template.name}
+                    </option>
+                  ))}
+                </select>
+              </Field>
 
-              <label className="lbl">
-                Description
-                <textarea name="description" placeholder="Optional notes" />
-              </label>
+              <Field label="Campaign Name">
+                <input
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  className="w-full border rounded p-2"
+                  placeholder="Weekend Promo Blast"
+                  required
+                />
+              </Field>
 
-              <label className="lbl">
-                Scheduled time
-                <input type="datetime-local" name="scheduled_at" required />
-              </label>
+              <Field label="Description (optional)">
+                <textarea
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                  className="w-full border rounded p-2"
+                  rows={3}
+                  placeholder="Short internal note…"
+                />
+              </Field>
 
-              <div className="modal-actions">
+              <Field label="Scheduled Time">
+                <input
+                  type="datetime-local"
+                  value={scheduledAt}
+                  onChange={(event) => setScheduledAt(event.target.value)}
+                  className="w-full border rounded p-2"
+                  required
+                />
+              </Field>
+
+              <Field label="Timezone (auto from Course)">
+                <input value={timezone} readOnly className="w-full border rounded p-2 bg-gray-50" />
+              </Field>
+
+              <div className="flex justify-end gap-2">
                 <button
                   type="button"
                   className="btn"
                   onClick={() => {
                     resetForm();
-                    setErr("");
                     setOpen(false);
                   }}
-                  disabled={pending}
+                  disabled={loading}
                 >
                   Cancel
                 </button>
-                <button
-                  className="btn-primary"
-                  disabled={pending || !orgId || !courseId || !templateId}
-                >
-                  {pending ? "Scheduling…" : "Schedule"}
+                <button type="submit" disabled={loading} className="px-4 py-2 rounded bg-black text-white disabled:opacity-60">
+                  {loading ? "Saving…" : "Schedule Campaign"}
                 </button>
               </div>
             </form>

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,9 +1,22 @@
-'use client';
-import { createBrowserClient } from '@supabase/ssr';
-import type { Database } from '../../types/database';
+"use client";
 
-export const supabaseBrowser = () =>
-  createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../../types/database";
+
+let _client: SupabaseClient<Database> | null = null;
+
+export function createSupabaseBrowserClient(): SupabaseClient<Database> {
+  if (_client) return _client;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY");
+  }
+
+  _client = createClient<Database>(url, anonKey);
+  return _client;
+}
+
+export const supabaseBrowser = createSupabaseBrowserClient;


### PR DESCRIPTION
## Summary
- add a cached browser Supabase client factory with named exports
- refactor AddPromoModal to load org/course/template data, require course selection, and insert calendar events

## Testing
- `npm run lint` *(fails: next not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e4b2384428832a886f0090c14da1f3