### PR TITLE
Fix calendar promo modal dropdown data

### DIFF
--- a/app/agency/calendar/page.tsx
+++ b/app/agency/calendar/page.tsx
@@ -2,6 +2,7 @@ import Calendar from "@/components/Calendar";
 import AddPromoModal from "./AddPromoModal";
 import { getAccessibleOrgs, getCalendarEventsForOwner } from "@/lib/agency";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createPromoAction } from "./actions";
 
 export const metadata = { title: "Agency • Calendar" };
 
@@ -17,25 +18,92 @@ export default async function Page() {
   }));
 
   const orgs = await getAccessibleOrgs();
+  const orgOptions = orgs.map((o) => ({ id: o.id as string, name: o.name as string }));
+  const orgIds = orgOptions.map((o) => o.id);
 
   const supabase = createSupabaseServerClient();
-  // include org_id so the modal can filter templates by selected org
-  const { data: templates } = await supabase
-    .from("rcs_templates")
-    .select("id, name, org_id")
-    .order("name", { ascending: true });
+
+  const courseOptionsByOrg: Record<string, { id: string; name: string; timezone: string }[]> = {};
+  const templateOptionsByOrg: Record<string, { id: string; name: string }[]> = {};
+
+  if (orgIds.length > 0) {
+    const [{ data: courses }, { data: templates }] = await Promise.all([
+      supabase
+        .from("courses")
+        .select("id, name, org_id, timezone")
+        .in("org_id", orgIds)
+        .order("name", { ascending: true }),
+      supabase
+        .from("rcs_templates")
+        .select("id, name, org_id")
+        .in("org_id", orgIds)
+        .order("name", { ascending: true }),
+    ]);
+
+    for (const course of courses ?? []) {
+      if (!course?.org_id || !course?.id || !course?.name) continue;
+      courseOptionsByOrg[course.org_id] = courseOptionsByOrg[course.org_id] ?? [];
+      courseOptionsByOrg[course.org_id].push({
+        id: course.id,
+        name: course.name,
+        timezone: course.timezone ?? "",
+      });
+    }
+
+    for (const template of templates ?? []) {
+      if (!template?.org_id || !template?.id || !template?.name) continue;
+      templateOptionsByOrg[template.org_id] = templateOptionsByOrg[template.org_id] ?? [];
+      templateOptionsByOrg[template.org_id].push({
+        id: template.id,
+        name: template.name,
+      });
+    }
+
+    for (const orgId of Object.keys(courseOptionsByOrg)) {
+      courseOptionsByOrg[orgId].sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    for (const orgId of Object.keys(templateOptionsByOrg)) {
+      templateOptionsByOrg[orgId].sort((a, b) => a.name.localeCompare(b.name));
+    }
+  }
 
   return (
     <div className="page">
       <div className="page-header">
         <h1 className="page-title">Calendar</h1>
         <AddPromoModal
-          orgOptions={orgs.map((o) => ({ id: o.id, name: o.name }))}
-          templateOptions={(templates ?? []).map((t) => ({
-            id: t.id,
-            name: t.name,
-            org_id: t.org_id,
-          }))}
+          orgOptions={orgOptions}
+          courseOptionsByOrg={courseOptionsByOrg}
+          templateOptionsByOrg={templateOptionsByOrg}
+          action={async (formData) => {
+            const getString = (key: string) => {
+              const value = formData.get(key);
+              return typeof value === "string" ? value.trim() : "";
+            };
+
+            const scheduledAtRaw = getString("scheduled_at");
+            const scheduledAtIso = (() => {
+              if (!scheduledAtRaw) return "";
+              const parsed = new Date(scheduledAtRaw);
+              return Number.isNaN(parsed.getTime()) ? "" : parsed.toISOString();
+            })();
+
+            await createPromoAction({
+              org_id: getString("org_id"),
+              course_id: getString("course_id"),
+              template_id: getString("template_id"),
+              name: getString("name"),
+              description: (() => {
+                const description = formData.get("description");
+                if (typeof description !== "string") return null;
+                const trimmed = description.trim();
+                return trimmed.length ? trimmed : null;
+              })(),
+              scheduled_at: scheduledAtIso,
+              timezone: getString("timezone"),
+            });
+          }}
         />
       </div>
       <div className="card">


### PR DESCRIPTION
## Summary
- fetch courses and templates per organization for the Add RCS Promo modal and call the existing create promo action
- update the client modal to manage required selections, auto-fill timezone from the chosen course, and guard submission when prerequisites are missing

## Testing
- npm run lint *(fails: Next.js binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e4b7619748832aad6270e87748a19c