### PR TITLE
Allow agency owners to manage all organizations

### DIFF
--- a/app/agency/calendar/AddPromoModal.tsx
+++ b/app/agency/calendar/AddPromoModal.tsx
@@ -71,7 +71,11 @@ export default function AddPromoModal({
   // Update timezone when course changes
   useEffect(() => {
     const course = courses.find((c) => c.id === courseId);
-    setTimezone(course?.timezone ?? '');
+    if (!course) {
+      setTimezone('');
+      return;
+    }
+    setTimezone(course.timezone ?? 'UTC');
   }, [courseId, courses]);
 
   const resetForm = () => {
@@ -270,9 +274,11 @@ export default function AddPromoModal({
 
               <Field label="Timezone (auto from Course)">
                 <input
+                  name="timezone"
                   value={timezone}
                   readOnly
                   className="input bg-muted"
+                  placeholder="Select a course to load timezone"
                   disabled={loading}
                 />
               </Field>

--- a/app/agency/calendar/CalendarWithEdit.tsx
+++ b/app/agency/calendar/CalendarWithEdit.tsx
@@ -30,7 +30,17 @@ type CalendarWithEditProps = {
   courseOptionsByOrg: Record<string, any[]>;
   templateOptionsByOrg: Record<string, any[]>;
   createPromoAction: (formData: FormData) => Promise<void>;
-  updateEventTimeAction: (eventId: string, newScheduledAt: string) => Promise<void>;
+  updateEventAction: (data: {
+    eventId: string;
+    campaignId: string;
+    name: string;
+    description: string | null;
+    scheduledAt: string;
+    timezone: string;
+    orgId: string;
+    courseId: string;
+    templateId: string;
+  }) => Promise<void>;
   cancelEventAction: (eventId: string) => Promise<void>;
 };
 
@@ -40,7 +50,7 @@ export default function CalendarWithEdit({
   courseOptionsByOrg,
   templateOptionsByOrg,
   createPromoAction,
-  updateEventTimeAction,
+  updateEventAction,
   cancelEventAction,
 }: CalendarWithEditProps) {
   const [selectedEvent, setSelectedEvent] = useState<EnrichedEvent | null>(null);
@@ -52,8 +62,18 @@ export default function CalendarWithEdit({
     }
   };
 
-  const handleUpdateEvent = async (eventId: string, newScheduledAt: string) => {
-    await updateEventTimeAction(eventId, newScheduledAt);
+  const handleUpdateEvent = async (data: {
+    eventId: string;
+    campaignId: string;
+    name: string;
+    description: string | null;
+    scheduledAt: string;
+    timezone: string;
+    orgId: string;
+    courseId: string;
+    templateId: string;
+  }) => {
+    await updateEventAction(data);
     setSelectedEvent(null);
     window.location.reload();
   };
@@ -120,7 +140,7 @@ export default function CalendarWithEdit({
           templateOptionsByOrg={templateOptionsByOrg}
           onClose={() => setSelectedEvent(null)}
           onUpdate={async (data) => {
-            await handleUpdateEvent(data.eventId, data.scheduledAt);
+            await handleUpdateEvent(data);
           }}
           onCancel={handleCancelEvent}
         />

--- a/app/agency/calendar/EditEventModal.tsx
+++ b/app/agency/calendar/EditEventModal.tsx
@@ -99,9 +99,10 @@ export default function EditEventModal({
   // Update timezone when course changes
   useEffect(() => {
     const course = courses.find((c) => c.id === courseId);
-    if (course) {
-      setTimezone(course.timezone);
+    if (!course) {
+      return;
     }
+    setTimezone(course.timezone ?? 'UTC');
   }, [courseId, courses]);
 
   if (!event) return null;

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -46,6 +46,11 @@ export const getCurrentProfile = cache(async (): Promise<Profile | null> => {
 /**
  * Check if user has global owner or agency_staff role
  */
+export async function isOwner(): Promise<boolean> {
+  const profile = await getCurrentProfile();
+  return profile?.role === 'owner';
+}
+
 export async function isAgencyUser(): Promise<boolean> {
   const profile = await getCurrentProfile();
   return profile?.role === 'owner' || profile?.role === 'agency_staff';


### PR DESCRIPTION
## Summary
- ensure agency owners load all organizations, courses, templates, and promos instead of filtering by membership
- derive course timezone data automatically for promo scheduling and editing while validating cross-organization selections
- update calendar modals to submit complete payloads and expose timezone selection for owners

## Testing
- npm run lint *(fails: prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e59a0a5ef0832a9b1af13bea4972de