### PR TITLE
Fix Supabase admin env usage for agency invites

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -2,6 +2,101 @@ import { cookies, headers } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import type { Database } from '../../types/database';
 
+type DenoEnv = { env?: { get(name: string): string | undefined } };
+type GlobalWithDeno = typeof globalThis & { Deno?: DenoEnv };
+
+const globalWithDeno = globalThis as GlobalWithDeno;
+
+function readEnvVar(name: string): string | undefined {
+  const denoEnvGetter = globalWithDeno?.Deno?.env?.get;
+
+  if (typeof denoEnvGetter === 'function') {
+    try {
+      const denoValue = denoEnvGetter(name);
+      if (typeof denoValue === 'string' && denoValue.length > 0) {
+        return denoValue;
+      }
+    } catch (error) {
+      console.error('Unable to read environment variable from Deno.env', {
+        name,
+        error,
+      });
+    }
+  }
+
+  const nodeValue =
+    typeof process !== 'undefined' && process?.env ? process.env[name] : undefined;
+
+  return typeof nodeValue === 'string' && nodeValue.length > 0 ? nodeValue : undefined;
+}
+
+function normalizeEnvValue(value: string | undefined | null) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function getEnvValueFromKeys(keys: readonly string[]) {
+  for (const key of keys) {
+    const candidate = normalizeEnvValue(readEnvVar(key));
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return '';
+}
+
+const SERVICE_ROLE_ENV_KEYS = [
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'SUPABASE_SERVICE_ROLE',
+  'SUPABASE_SERVICE_KEY',
+  'SUPABASE_SERVICE_ROLE_SECRET',
+] as const;
+
+const SUPABASE_URL_ENV_KEYS = ['NEXT_PUBLIC_SUPABASE_URL', 'SUPABASE_URL'] as const;
+
+const SUPABASE_ANON_KEY_ENV_KEYS = [
+  'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+  'SUPABASE_ANON_KEY',
+] as const;
+
+export function getSupabaseServiceRoleKey(): string | null {
+  const resolved = getEnvValueFromKeys(SERVICE_ROLE_ENV_KEYS);
+
+  return resolved || null;
+}
+
+export function getSupabaseUrl(): string | null {
+  const resolved = getEnvValueFromKeys(SUPABASE_URL_ENV_KEYS);
+
+  return resolved || null;
+}
+
+export function getSupabaseAnonKey(): string | null {
+  const resolved = getEnvValueFromKeys(SUPABASE_ANON_KEY_ENV_KEYS);
+
+  return resolved || null;
+}
+
+function resolveSupabaseUrlOrThrow() {
+  const supabaseUrl = getSupabaseUrl();
+
+  if (!supabaseUrl) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL is not configured');
+  }
+
+  return supabaseUrl;
+}
+
+function resolveSupabaseAnonKeyOrThrow() {
+  const anonKey = getSupabaseAnonKey();
+
+  if (!anonKey) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY is not configured');
+  }
+
+  return anonKey;
+}
+
 /**
  * Read-only client for Server Components (no cookie writes).
  *
@@ -10,8 +105,8 @@ import type { Database } from '../../types/database';
 export function createSupabaseServerClient() {
   const cookieStore = cookies();
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    resolveSupabaseUrlOrThrow(),
+    resolveSupabaseAnonKeyOrThrow(),
     {
       cookies: {
         getAll() {
@@ -32,8 +127,8 @@ export function createSupabaseServerClient() {
 export function createSupabaseActionClient() {
   const cookieStore = cookies();
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    resolveSupabaseUrlOrThrow(),
+    resolveSupabaseAnonKeyOrThrow(),
     {
       cookies: {
         getAll() {
@@ -50,41 +145,27 @@ export function createSupabaseActionClient() {
   ) as any;
 }
 
-const SERVICE_ROLE_ENV_KEYS = [
-  'SUPABASE_SERVICE_ROLE_KEY',
-  'SUPABASE_SERVICE_ROLE',
-  'SUPABASE_SERVICE_KEY',
-  'SUPABASE_SERVICE_ROLE_SECRET',
-] as const;
-
-function normalizeEnvValue(value: string | undefined | null) {
-  return typeof value === 'string' ? value.trim() : '';
-}
-
-export function getSupabaseServiceRoleKey(): string | null {
-  for (const key of SERVICE_ROLE_ENV_KEYS) {
-    const candidate = normalizeEnvValue(process.env[key]);
-    if (candidate) {
-      return candidate;
-    }
-  }
-
-  return null;
-}
-
 /**
  * Admin client for cron/webhooks (service role; bypasses RLS by design).
  */
-export function createSupabaseAdminClient(serviceRoleKey?: string) {
+export function createSupabaseAdminClient(
+  serviceRoleKey?: string,
+  supabaseUrl?: string
+) {
   const resolvedKey = normalizeEnvValue(serviceRoleKey ?? getSupabaseServiceRoleKey());
+  const resolvedUrl = normalizeEnvValue(supabaseUrl ?? getSupabaseUrl());
 
   if (!resolvedKey) {
     throw new Error('SUPABASE_SERVICE_ROLE_KEY is not configured');
   }
 
+  if (!resolvedUrl) {
+    throw new Error('NEXT_PUBLIC_SUPABASE_URL is not configured');
+  }
+
   const { createClient } = require('@supabase/supabase-js');
   return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    resolvedUrl,
     resolvedKey,
     { auth: { persistSession: false, autoRefreshToken: false } } as any
   ) as any;


### PR DESCRIPTION
## Summary
- read Supabase admin credentials via environment helpers that support Deno and Node runtimes
- guard agency invite action with clearer configuration checks and improved error handling
- reuse the new helpers so all server clients share the same environment resolution

## Testing
- npm run lint *(fails: Next.js lint command prompts for initial configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68e5e4084658832a8ce3d5cd73ee4d33